### PR TITLE
Fix hutil procedure when error occurs

### DIFF
--- a/OmsAgent/Fairfax/omsagent_ff.py
+++ b/OmsAgent/Fairfax/omsagent_ff.py
@@ -77,7 +77,7 @@ def main():
 
         waagent.Error(err_msg)
         hutil.error(err_msg)
-        hutil.do_exit(exit_code, 'Enable','failed','0',
+        hutil.do_exit(exit_code, 'Enable','failed', str(exit_code),
                       'Enable failed: {0}'.format(e))
 
 

--- a/OmsAgent/omsagent.py
+++ b/OmsAgent/omsagent.py
@@ -77,7 +77,7 @@ def main():
 
         waagent.Error(err_msg)
         hutil.error(err_msg)
-        hutil.do_exit(exit_code, 'Enable','failed','0',
+        hutil.do_exit(exit_code, 'Enable','failed', str(exit_code),
                       'Enable failed: {0}'.format(e))
 
 


### PR DESCRIPTION
@varunkumta 

When hutil.do_exit is called upon an error in the python handler, it always returns '0' as the code instead of a string representing the exit_code. I have fixed this. (Let me know if the code was this way by design.