### PR TITLE
Improve exit codes and add error code processing

### DIFF
--- a/OmsAgent/Fairfax/HandlerManifest.json
+++ b/OmsAgent/Fairfax/HandlerManifest.json
@@ -1,7 +1,7 @@
 [
   {
     "name":  "OmsAgentForLinux",
-    "version": "1.3.18.4",
+    "version": "1.3.18.5",
     "handlerManifest": {
       "installCommand": "omsagent_ff.py -install",
       "uninstallCommand": "omsagent_ff.py -uninstall",

--- a/OmsAgent/Fairfax/HandlerManifest.json
+++ b/OmsAgent/Fairfax/HandlerManifest.json
@@ -1,7 +1,7 @@
 [
   {
     "name":  "OmsAgentForLinux",
-    "version": "1.3.15.2",
+    "version": "1.3.18.4",
     "handlerManifest": {
       "installCommand": "omsagent_ff.py -install",
       "uninstallCommand": "omsagent_ff.py -uninstall",

--- a/OmsAgent/Fairfax/omsagent_ff.py
+++ b/OmsAgent/Fairfax/omsagent_ff.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-#OmsAgent extension
+# OmsAgentForLinux Extension
 #
 # Copyright 2015 Microsoft Corporation
 #
@@ -29,12 +29,11 @@ import Utils.ScriptUtil as ScriptUtil
 
 # Global Variables
 ExtensionShortName = "OmsAgentForLinux"
-
 PackagesDirectory = "packages"
-BundleFileName = 'omsagent-1.3.1-15.universal.x64.sh'
+BundleFileName = 'omsagent-1.3.3-15.universal.x64.sh'
 
-# always use upgrade - will handle install if scx, omi are not installed or upgrade if they are
-InstallCommandTemplate = './{0} --upgrade --force'
+# Always use upgrade - will handle install if scx, omi are not installed or upgrade if they are
+InstallCommandTemplate = './{0} --upgrade'
 UninstallCommandTemplate = './{0} --remove'
 OmsAdminWorkingDirectory = '/opt/microsoft/omsagent/bin'
 WorkspaceCheckCommand = './omsadmin.sh -l'
@@ -42,6 +41,13 @@ OnboardCommandWithOptionalParamsTemplate = './omsadmin.sh -d opinsights.azure.us
 ServiceControlWorkingDirectory = '/opt/microsoft/omsagent/bin'
 DisableOmsAgentServiceCommand = './service_control disable'
 EnableOmsAgentServiceCommand = './service_control enable'
+
+# Dictionary of operations strings to methods
+operations = {'Disable' : disable,
+              'Uninstall' : uninstall,
+              'Install' : install,
+              'Enable' : enable
+}
 
 # Change permission of log path
 ext_log_path = '/var/log/azure/'
@@ -52,44 +58,73 @@ def main():
     waagent.LoggerInit('/var/log/waagent.log','/dev/stdout', True)
     waagent.Log("%s started to handle." %(ExtensionShortName))
 
+    # Determine the operation being executed
+    operation = None
     try:
         for a in sys.argv[1:]:
             if re.match("^([-/]*)(disable)", a):
-                hutil = parse_context("Disable")
-                disable(hutil)
+                operation = 'Disable'
             elif re.match("^([-/]*)(uninstall)", a):
-                hutil = parse_context("Uninstall")
-                uninstall(hutil)
+                operation = 'Uninstall'
             elif re.match("^([-/]*)(install)", a):
-                hutil = parse_context("Install")
-                install(hutil)
+                operation = 'Install'
             elif re.match("^([-/]*)(enable)", a):
-                hutil = parse_context("Enable")
-                enable(hutil)
+                operation = 'Enable'
             elif re.match("^([-/]*)(update)", a):
-                dummy_command("Update", "success", "Update succeeded")
+                operation = 'Update'
+    except Exception as e:
+        waagent.Error(e.message)
+
+    # Set up for exit code and any error messages
+    exit_code = 0
+    message = operation + ' succeeded'
+
+    # Invoke operation
+    try:
+        if operation is 'Update':
+            # Upgrade is noop since omsagent.py->install() will be called everytime upgrade
+            #   is done due to upgradeMode = "UpgradeWithInstall" set in HandlerManifest
+            dummy_command(operation, 'success', operation + ' succeeded')
+        elif operation in operations:
+            hutil = parse_context(operation)
+            exit_code = operations[operation](hutil)
+            if exit_code is not 0:
+                # If Daniel replies favorably, then if an exit code is among the pre-reqs we can return that and print out the pre-req
+                message = (operation + ' failed with exit code {0}').format(exit_code)
+
+    except ValueError as e:
+        exit_code = 11
+        message = (operation + ' failed with error: {0}').format(e.message)
+
     except Exception as e:
         exit_code = 1
-        err_msg = ("Failed with error: {0}, {1}").format(e, traceback.format_exc())
+        message = (operation + ' failed with error: {0}, {1}').format(e, traceback.format_exc())
+
         if "LINUXOMSAGENTEXTENSION_ERROR_MULTIPLECONNECTIONS" in str(e):
             exit_code = 10
-            err_msg = ("Failed with error: {0}").format(e)
+            message = (operation + ' failed with error: {0}').format(e.message)
 
-        waagent.Error(err_msg)
-        hutil.error(err_msg)
-        hutil.do_exit(exit_code, 'Enable','failed', str(exit_code),
-                      'Enable failed: {0}'.format(e))
+    # Finish up and log messages
+    if exit_code is 0:
+        waagent.Log(message)
+        hutil.log(message)
+        hutil.do_exit(exit_code, operation, 'success', str(exit_code), message)
+    else:
+        waagent.Error(message)
+        hutil.error(message)
+        hutil.do_exit(exit_code, operation, 'failed', str(exit_code), message)
 
 
 def parse_context(operation):
     hutil = Util.HandlerUtility(waagent.Log, waagent.Error)
     hutil.do_parse_context(operation)
     return hutil
-    
-    
+
+
 def dummy_command(operation, status, msg):
     hutil = parse_context(operation)
     hutil.do_exit(0, operation, status, '0', msg)
+    return 0
 
 
 def install(hutil):
@@ -98,25 +133,30 @@ def install(hutil):
 
     os.chmod(file_path, 100)
     cmd = InstallCommandTemplate.format(BundleFileName)
-    ScriptUtil.run_command(hutil, ScriptUtil.parse_args(cmd), file_directory, 'Install', ExtensionShortName, hutil.get_extension_version())
+    waagent.Log("Starting command %s --upgrade." %(BundleFileName))
+    exit_code = ScriptUtil.run_command(hutil, ScriptUtil.parse_args(cmd), file_directory, 'Install',
+                                       ExtensionShortName, hutil.get_extension_version())
+    return exit_code
 
 
 def uninstall(hutil):
-    file_directory = os.path.join(os.getcwd(), PackagesDirectory)    
+    file_directory = os.path.join(os.getcwd(), PackagesDirectory)
 
     cmd = UninstallCommandTemplate.format(BundleFileName)
-    ScriptUtil.run_command(hutil, ScriptUtil.parse_args(cmd), file_directory, 'Uninstall', ExtensionShortName, hutil.get_extension_version())
+    waagent.Log("Starting command %s --remove." %(BundleFileName))
+    exit_code = ScriptUtil.run_command(hutil, ScriptUtil.parse_args(cmd), file_directory, 'Uninstall',
+                                       ExtensionShortName, hutil.get_extension_version())
+    return exit_code
 
 
 def enable(hutil):
-    hutil.exit_if_enabled()
-
+    waagent.Log("Handler not enabled. Starting onboarding.")
     public_settings = hutil.get_public_settings()
     protected_settings = hutil.get_protected_settings()
     if public_settings is None:
-        raise ValueError("Public configuration cannot be None.")
+        raise ValueError("Public configuration must be provided")
     if protected_settings is None:
-        raise ValueError("Private configuration cannot be None.")
+        raise ValueError("Private configuration must be provided")
 
     workspaceId = public_settings.get("workspaceId")
     workspaceKey = protected_settings.get("workspaceKey")
@@ -124,18 +164,24 @@ def enable(hutil):
     vmResourceId = protected_settings.get("vmResourceId")
     stopOnMultipleConnections = public_settings.get("stopOnMultipleConnections")
     if workspaceId is None:
-        raise ValueError("Workspace ID cannot be None.")
+        raise ValueError("Workspace ID must be provided")
     if workspaceKey is None:
-        raise ValueError("Workspace key cannot be None.")
+        raise ValueError("Workspace key must be provided")
 
     if stopOnMultipleConnections is not None and stopOnMultipleConnections is True:
         output_file = tempfile.NamedTemporaryFile('w')
         output_file.close()
 
-        list_exit_code = ScriptUtil.run_command(hutil, ScriptUtil.parse_args(WorkspaceCheckCommand), OmsAdminWorkingDirectory, 'Check If Already Onboarded', ExtensionShortName, hutil.get_extension_version(), False, interval = 30, std_out_file_name = output_file.name)
+        list_exit_code = ScriptUtil.run_command(hutil,
+                                                ScriptUtil.parse_args(WorkspaceCheckCommand),
+                                                OmsAdminWorkingDirectory,
+                                                'Check If Already Onboarded', ExtensionShortName,
+                                                hutil.get_extension_version(), False,
+                                                interval = 30,
+                                                std_out_file_name = output_file.name)
 
-        # If the printout includes "No Workspace" then there are no workspaces onboarded to the machine
-        # Otherwise the workspaces that have been onboarded are listed in the output
+        # If the printout includes "No Workspace" then there are no workspaces onboarded to the
+        #   machine; otherwise the workspaces that have been onboarded are listed in the output
         output_file_handle = open(output_file.name, 'r')
         connectionExists = False
         if "No Workspace" not in output_file_handle.read():
@@ -150,31 +196,43 @@ def enable(hutil):
                        "means this machine will get billed multiple times for "
                        "each workspace it report to. "
                        "(LINUXOMSAGENTEXTENSION_ERROR_MULTIPLECONNECTIONS)")
-            # This exception will get caught by the main clause
+            # This exception will get caught by the main method
             raise Exception(err_msg)
 
     proxyParam = ""
     if proxy is not None:
         proxyParam = "-p {0}".format(proxy)
-        
+
     vmResourceIdParam = ""
     if vmResourceId is not None:
         vmResourceIdParam = "-a {0}".format(vmResourceId)
 
     optionalParams = "{0} {1}".format(proxyParam, vmResourceIdParam)
-    cmd = OnboardCommandWithOptionalParamsTemplate.format(workspaceId, workspaceKey, optionalParams)
+    cmd = OnboardCommandWithOptionalParamsTemplate.format(workspaceId, workspaceKey,
+                                                          optionalParams)
 
-    exit_code = ScriptUtil.run_command(hutil, ScriptUtil.parse_args(cmd), OmsAdminWorkingDirectory, 'Onboard', ExtensionShortName, hutil.get_extension_version(), False)
+    exit_code = ScriptUtil.run_command(hutil, ScriptUtil.parse_args(cmd), OmsAdminWorkingDirectory,
+                                       'Onboard', ExtensionShortName,
+                                       hutil.get_extension_version(), False)
 
-    # if onboard succeeds we continue, otherwise fail fast
+    # If onboard succeeds we continue, otherwise fail fast
     if exit_code == 0:
-        ScriptUtil.run_command(hutil, ScriptUtil.parse_args(EnableOmsAgentServiceCommand), ServiceControlWorkingDirectory, 'Enable', ExtensionShortName, hutil.get_extension_version())
+        exit_code = ScriptUtil.run_command(hutil,
+                                           ScriptUtil.parse_args(EnableOmsAgentServiceCommand),
+                                           ServiceControlWorkingDirectory, 'Enable',
+                                           ExtensionShortName, hutil.get_extension_version())
     else:
-        sys.exit(exit_code)
+        hutil.error(('Onboard failed with exit code {0}; Enable not attempted').format(exit_code)
+
+    return exit_code
 
 
 def disable(hutil):
-    ScriptUtil.run_command(hutil, ScriptUtil.parse_args(DisableOmsAgentServiceCommand), ServiceControlWorkingDirectory, 'Disable', ExtensionShortName, hutil.get_extension_version())
+    exit_code = ScriptUtil.run_command(hutil,
+                                       ScriptUtil.parse_args(DisableOmsAgentServiceCommand),
+                                       ServiceControlWorkingDirectory, 'Disable',
+                                       ExtensionShortName, hutil.get_extension_version())
+    return exit_code
 
 
 if __name__ == '__main__' :

--- a/OmsAgent/HandlerManifest.json
+++ b/OmsAgent/HandlerManifest.json
@@ -1,7 +1,7 @@
 [
   {
     "name":  "OmsAgentForLinux",
-    "version": "1.3.15.2",
+    "version": "1.3.18.4",
     "handlerManifest": {
       "installCommand": "omsagent.py -install",
       "uninstallCommand": "omsagent.py -uninstall",

--- a/OmsAgent/HandlerManifest.json
+++ b/OmsAgent/HandlerManifest.json
@@ -1,7 +1,7 @@
 [
   {
     "name":  "OmsAgentForLinux",
-    "version": "1.3.18.4",
+    "version": "1.3.18.5",
     "handlerManifest": {
       "installCommand": "omsagent.py -install",
       "uninstallCommand": "omsagent.py -uninstall",

--- a/OmsAgent/README.md
+++ b/OmsAgent/README.md
@@ -212,14 +212,14 @@ Set-AzureRmVMExtension -ResourceGroupName $RGName -VMName $VmName -Location $Loc
 ```
 
 ## Supported Linux Distributions
-- CentOS Linux 5,6, and 7 (x86/x64)
-- Oracle Linux 5,6, and 7 (x86/x64)
-- Red Hat Enterprise Linux Server 5,6 and 7 (x86/x64)
-- Debian GNU/Linux 6, 7, and 8 (x86/x64)
-- Ubuntu 12.04 LTS, 14.04 LTS, 15.04 (x86/x64)
-- SUSE Linux Enterprise Server 11 and 12 (x86/x64)
+* CentOS Linux 5,6, and 7 (x86/x64)
+* Oracle Linux 5,6, and 7 (x86/x64)
+* Red Hat Enterprise Linux Server 5,6 and 7 (x86/x64)
+* Debian GNU/Linux 6, 7, and 8 (x86/x64)
+* Ubuntu 12.04 LTS, 14.04 LTS, 15.04, 15.10, 16.04 LTS (x86/x64)
+* SUSE Linux Enteprise Server 11 and 12 (x86/x64)
 
-## Debug
+## Troubleshooting
 
 * The status of the extension is reported back to Azure so that user can
 see the status on Azure Portal
@@ -230,9 +230,32 @@ and the tail of the output is logged into the log directory specified
 in HandlerEnvironment.json and reported back to Azure
 * The operation log of the extension is `/var/log/azure/<extension-name>/<version>/extension.log` file.
 
+### Error codes and their meanings
+
+| Error Code | Meaning | Possible Action |
+| :---: | --- | --- |
+| 2 | Invalid option provided to the shell bundle | |
+| 3 | No option provided to the shell bundle | |
+| 4 | Invalid package type | |
+| 5 | The shell bundle must be executed as root | |
+| 6 | Invalid package architecture | |
+| 10 | VM is already connected to an OMS workspace | To connect the VM to the workspace specified in the extension schema, set stopOnMultipleConnections to false in public settings or remove this property. This VM gets billed once for each workspace it is connected to. |
+| 11 | Invalid config provided to the extension | Follow the preceding examples to set all property values necessary for deployment. |
+| 20 | Installation of SCX/OMI failed | |
+| 21 | Installation of SCX/Provider kits failed | |
+| 22 | Installation of bundled package failed | |
+| 23 | SCX or OMI package already installed | |
+| 30 | Internal bundle error | |
+| 51 | This extension is not supported on the VM's operation system | |
+| 60 | Unsupported version of OpenSSL | Install a version of OpenSSL meeting our [package requirements](https://github.com/Microsoft/OMS-Agent-for-Linux/blob/master/docs/OMS-Agent-for-Linux.md#package-requirements). |
+| 61 | Missing Python ctypes library | Install the Python ctypes library or package (python-ctypes). |
+| 62 | Missing tar program | Install tar. |
+| 63 | Missing sed program | Install sed. |
+
+Additional troubleshooting information can be found on the [OMS-Agent-for-Linux Troubleshooting Guide](https://github.com/Microsoft/OMS-Agent-for-Linux/blob/master/docs/Troubleshooting.md#).
+
 
 [azure-powershell]: https://azure.microsoft.com/en-us/documentation/articles/powershell-install-configure/
 [azure-cli]: https://azure.microsoft.com/en-us/documentation/articles/xplat-cli/
 [arm-template]: http://azure.microsoft.com/en-us/documentation/templates/ 
 [arm-overview]: https://azure.microsoft.com/en-us/documentation/articles/resource-group-overview/
-[Set-AzureVMExtension-ARM]: https://msdn.microsoft.com/en-us/library/mt163544.aspx

--- a/OmsAgent/omsagent.py
+++ b/OmsAgent/omsagent.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-#OmsAgent extension
+# OmsAgentForLinux Extension
 #
 # Copyright 2015 Microsoft Corporation
 #
@@ -29,12 +29,11 @@ import Utils.ScriptUtil as ScriptUtil
 
 # Global Variables
 ExtensionShortName = "OmsAgentForLinux"
-
 PackagesDirectory = "packages"
-BundleFileName = 'omsagent-1.3.1-15.universal.x64.sh'
+BundleFileName = 'omsagent-1.3.3-15.universal.x64.sh'
 
-# always use upgrade - will handle install if scx, omi are not installed or upgrade if they are
-InstallCommandTemplate = './{0} --upgrade --force'
+# Always use upgrade - will handle install if scx, omi are not installed or upgrade if they are
+InstallCommandTemplate = './{0} --upgrade'
 UninstallCommandTemplate = './{0} --remove'
 OmsAdminWorkingDirectory = '/opt/microsoft/omsagent/bin'
 WorkspaceCheckCommand = './omsadmin.sh -l'
@@ -42,6 +41,13 @@ OnboardCommandWithOptionalParamsTemplate = './omsadmin.sh -w {0} -s {1} {2}'
 ServiceControlWorkingDirectory = '/opt/microsoft/omsagent/bin'
 DisableOmsAgentServiceCommand = './service_control disable'
 EnableOmsAgentServiceCommand = './service_control enable'
+
+# Dictionary of operations strings to methods
+operations = {'Disable' : disable,
+              'Uninstall' : uninstall,
+              'Install' : install,
+              'Enable' : enable
+}
 
 # Change permission of log path
 ext_log_path = '/var/log/azure/'
@@ -52,44 +58,73 @@ def main():
     waagent.LoggerInit('/var/log/waagent.log','/dev/stdout', True)
     waagent.Log("%s started to handle." %(ExtensionShortName))
 
+    # Determine the operation being executed
+    operation = None
     try:
         for a in sys.argv[1:]:
             if re.match("^([-/]*)(disable)", a):
-                hutil = parse_context("Disable")
-                disable(hutil)
+                operation = 'Disable'
             elif re.match("^([-/]*)(uninstall)", a):
-                hutil = parse_context("Uninstall")
-                uninstall(hutil)
+                operation = 'Uninstall'
             elif re.match("^([-/]*)(install)", a):
-                hutil = parse_context("Install")
-                install(hutil)
+                operation = 'Install'
             elif re.match("^([-/]*)(enable)", a):
-                hutil = parse_context("Enable")
-                enable(hutil)
+                operation = 'Enable'
             elif re.match("^([-/]*)(update)", a):
-                dummy_command("Update", "success", "Update succeeded")
+                operation = 'Update'
+    except Exception as e:
+        waagent.Error(e.message)
+
+    # Set up for exit code and any error messages
+    exit_code = 0
+    message = operation + ' succeeded'
+
+    # Invoke operation
+    try:
+        if operation is 'Update':
+            # Upgrade is noop since omsagent.py->install() will be called everytime upgrade
+            #   is done due to upgradeMode = "UpgradeWithInstall" set in HandlerManifest
+            dummy_command(operation, 'success', operation + ' succeeded')
+        elif operation in operations:
+            hutil = parse_context(operation)
+            exit_code = operations[operation](hutil)
+            if exit_code is not 0:
+                # If Daniel replies favorably, then if an exit code is among the pre-reqs we can return that and print out the pre-req
+                message = (operation + ' failed with exit code {0}').format(exit_code)
+
+    except ValueError as e:
+        exit_code = 11
+        message = (operation + ' failed with error: {0}').format(e.message)
+
     except Exception as e:
         exit_code = 1
-        err_msg = ("Failed with error: {0}, {1}").format(e, traceback.format_exc())
+        message = (operation + ' failed with error: {0}, {1}').format(e, traceback.format_exc())
+
         if "LINUXOMSAGENTEXTENSION_ERROR_MULTIPLECONNECTIONS" in str(e):
             exit_code = 10
-            err_msg = ("Failed with error: {0}").format(e)
+            message = (operation + ' failed with error: {0}').format(e.message)
 
-        waagent.Error(err_msg)
-        hutil.error(err_msg)
-        hutil.do_exit(exit_code, 'Enable','failed', str(exit_code),
-                      'Enable failed: {0}'.format(e))
+    # Finish up and log messages
+    if exit_code is 0:
+        waagent.Log(message)
+        hutil.log(message)
+        hutil.do_exit(exit_code, operation, 'success', str(exit_code), message)
+    else:
+        waagent.Error(message)
+        hutil.error(message)
+        hutil.do_exit(exit_code, operation, 'failed', str(exit_code), message)
 
 
 def parse_context(operation):
     hutil = Util.HandlerUtility(waagent.Log, waagent.Error)
     hutil.do_parse_context(operation)
     return hutil
-    
-    
+
+
 def dummy_command(operation, status, msg):
     hutil = parse_context(operation)
     hutil.do_exit(0, operation, status, '0', msg)
+    return 0
 
 
 def install(hutil):
@@ -98,25 +133,30 @@ def install(hutil):
 
     os.chmod(file_path, 100)
     cmd = InstallCommandTemplate.format(BundleFileName)
-    ScriptUtil.run_command(hutil, ScriptUtil.parse_args(cmd), file_directory, 'Install', ExtensionShortName, hutil.get_extension_version())
+    waagent.Log("Starting command %s --upgrade." %(BundleFileName))
+    exit_code = ScriptUtil.run_command(hutil, ScriptUtil.parse_args(cmd), file_directory, 'Install',
+                                       ExtensionShortName, hutil.get_extension_version())
+    return exit_code
 
 
 def uninstall(hutil):
-    file_directory = os.path.join(os.getcwd(), PackagesDirectory)    
+    file_directory = os.path.join(os.getcwd(), PackagesDirectory)
 
     cmd = UninstallCommandTemplate.format(BundleFileName)
-    ScriptUtil.run_command(hutil, ScriptUtil.parse_args(cmd), file_directory, 'Uninstall', ExtensionShortName, hutil.get_extension_version())
+    waagent.Log("Starting command %s --remove." %(BundleFileName))
+    exit_code = ScriptUtil.run_command(hutil, ScriptUtil.parse_args(cmd), file_directory, 'Uninstall',
+                                       ExtensionShortName, hutil.get_extension_version())
+    return exit_code
 
 
 def enable(hutil):
-    hutil.exit_if_enabled()
-
+    waagent.Log("Handler not enabled. Starting onboarding.")
     public_settings = hutil.get_public_settings()
     protected_settings = hutil.get_protected_settings()
     if public_settings is None:
-        raise ValueError("Public configuration cannot be None.")
+        raise ValueError("Public configuration must be provided")
     if protected_settings is None:
-        raise ValueError("Private configuration cannot be None.")
+        raise ValueError("Private configuration must be provided")
 
     workspaceId = public_settings.get("workspaceId")
     workspaceKey = protected_settings.get("workspaceKey")
@@ -124,18 +164,24 @@ def enable(hutil):
     vmResourceId = protected_settings.get("vmResourceId")
     stopOnMultipleConnections = public_settings.get("stopOnMultipleConnections")
     if workspaceId is None:
-        raise ValueError("Workspace ID cannot be None.")
+        raise ValueError("Workspace ID must be provided")
     if workspaceKey is None:
-        raise ValueError("Workspace key cannot be None.")
+        raise ValueError("Workspace key must be provided")
 
     if stopOnMultipleConnections is not None and stopOnMultipleConnections is True:
         output_file = tempfile.NamedTemporaryFile('w')
         output_file.close()
 
-        list_exit_code = ScriptUtil.run_command(hutil, ScriptUtil.parse_args(WorkspaceCheckCommand), OmsAdminWorkingDirectory, 'Check If Already Onboarded', ExtensionShortName, hutil.get_extension_version(), False, interval = 30, std_out_file_name = output_file.name)
+        list_exit_code = ScriptUtil.run_command(hutil,
+                                                ScriptUtil.parse_args(WorkspaceCheckCommand),
+                                                OmsAdminWorkingDirectory,
+                                                'Check If Already Onboarded', ExtensionShortName,
+                                                hutil.get_extension_version(), False,
+                                                interval = 30,
+                                                std_out_file_name = output_file.name)
 
-        # If the printout includes "No Workspace" then there are no workspaces onboarded to the machine
-        # Otherwise the workspaces that have been onboarded are listed in the output
+        # If the printout includes "No Workspace" then there are no workspaces onboarded to the
+        #   machine; otherwise the workspaces that have been onboarded are listed in the output
         output_file_handle = open(output_file.name, 'r')
         connectionExists = False
         if "No Workspace" not in output_file_handle.read():
@@ -150,31 +196,43 @@ def enable(hutil):
                        "means this machine will get billed multiple times for "
                        "each workspace it report to. "
                        "(LINUXOMSAGENTEXTENSION_ERROR_MULTIPLECONNECTIONS)")
-            # This exception will get caught by the main clause
+            # This exception will get caught by the main method
             raise Exception(err_msg)
 
     proxyParam = ""
     if proxy is not None:
         proxyParam = "-p {0}".format(proxy)
-        
+
     vmResourceIdParam = ""
     if vmResourceId is not None:
         vmResourceIdParam = "-a {0}".format(vmResourceId)
 
     optionalParams = "{0} {1}".format(proxyParam, vmResourceIdParam)
-    cmd = OnboardCommandWithOptionalParamsTemplate.format(workspaceId, workspaceKey, optionalParams)
+    cmd = OnboardCommandWithOptionalParamsTemplate.format(workspaceId, workspaceKey,
+                                                          optionalParams)
 
-    exit_code = ScriptUtil.run_command(hutil, ScriptUtil.parse_args(cmd), OmsAdminWorkingDirectory, 'Onboard', ExtensionShortName, hutil.get_extension_version(), False)
+    exit_code = ScriptUtil.run_command(hutil, ScriptUtil.parse_args(cmd), OmsAdminWorkingDirectory,
+                                       'Onboard', ExtensionShortName,
+                                       hutil.get_extension_version(), False)
 
-    # if onboard succeeds we continue, otherwise fail fast
+    # If onboard succeeds we continue, otherwise fail fast
     if exit_code == 0:
-        ScriptUtil.run_command(hutil, ScriptUtil.parse_args(EnableOmsAgentServiceCommand), ServiceControlWorkingDirectory, 'Enable', ExtensionShortName, hutil.get_extension_version())
+        exit_code = ScriptUtil.run_command(hutil,
+                                           ScriptUtil.parse_args(EnableOmsAgentServiceCommand),
+                                           ServiceControlWorkingDirectory, 'Enable',
+                                           ExtensionShortName, hutil.get_extension_version())
     else:
-        sys.exit(exit_code)
+        hutil.error(('Onboard failed with exit code {0}; Enable not attempted').format(exit_code)
+
+    return exit_code
 
 
 def disable(hutil):
-    ScriptUtil.run_command(hutil, ScriptUtil.parse_args(DisableOmsAgentServiceCommand), ServiceControlWorkingDirectory, 'Disable', ExtensionShortName, hutil.get_extension_version())
+    exit_code = ScriptUtil.run_command(hutil,
+                                       ScriptUtil.parse_args(DisableOmsAgentServiceCommand),
+                                       ServiceControlWorkingDirectory, 'Disable',
+                                       ExtensionShortName, hutil.get_extension_version())
+    return exit_code
 
 
 if __name__ == '__main__' :

--- a/OmsAgent/omsagent.py
+++ b/OmsAgent/omsagent.py
@@ -42,13 +42,6 @@ ServiceControlWorkingDirectory = '/opt/microsoft/omsagent/bin'
 DisableOmsAgentServiceCommand = './service_control disable'
 EnableOmsAgentServiceCommand = './service_control enable'
 
-# Dictionary of operations strings to methods
-operations = {'Disable' : disable,
-              'Uninstall' : uninstall,
-              'Install' : install,
-              'Enable' : enable
-}
-
 # Change permission of log path
 ext_log_path = '/var/log/azure/'
 if os.path.exists(ext_log_path):
@@ -222,7 +215,7 @@ def enable(hutil):
                                            ServiceControlWorkingDirectory, 'Enable',
                                            ExtensionShortName, hutil.get_extension_version())
     else:
-        hutil.error(('Onboard failed with exit code {0}; Enable not attempted').format(exit_code)
+        hutil.error(('Onboard failed with exit code {0}; Enable not attempted'i).format(exit_code))
 
     return exit_code
 
@@ -233,6 +226,14 @@ def disable(hutil):
                                        ServiceControlWorkingDirectory, 'Disable',
                                        ExtensionShortName, hutil.get_extension_version())
     return exit_code
+
+
+# Dictionary of operations strings to methods
+operations = {'Disable' : disable,
+              'Uninstall' : uninstall,
+              'Install' : install,
+              'Enable' : enable
+}
 
 
 if __name__ == '__main__' :

--- a/OmsAgent/omsagent.py
+++ b/OmsAgent/omsagent.py
@@ -23,6 +23,7 @@ import sys
 import traceback
 import tempfile
 import time
+import platform
 
 from Utils.WAAgentUtil import waagent
 import Utils.HandlerUtil as Util
@@ -31,7 +32,7 @@ import Utils.ScriptUtil as ScriptUtil
 # Global Variables
 ExtensionShortName = "OmsAgentForLinux"
 PackagesDirectory = "packages"
-BundleFileName = 'omsagent-1.3.3-15.universal.x64.sh'
+BundleFileName = 'omsagent-1.3.4-15.universal.x64.sh'
 
 # Always use upgrade - will handle install if scx, omi are not installed or upgrade if they are
 InstallCommandTemplate = './{0} --upgrade'
@@ -47,6 +48,7 @@ EnableOmsAgentServiceCommand = './service_control enable'
 ext_log_path = '/var/log/azure/'
 if os.path.exists(ext_log_path):
     os.chmod(ext_log_path, 700)
+
 
 def main():
     waagent.LoggerInit('/var/log/waagent.log','/dev/stdout', True)
@@ -75,16 +77,14 @@ def main():
 
     # Invoke operation
     try:
-        if operation is 'Update':
-            # Upgrade is noop since omsagent.py->install() will be called everytime upgrade
-            #   is done due to upgradeMode = "UpgradeWithInstall" set in HandlerManifest
-            dummy_command(operation, 'success', operation + ' succeeded')
-        elif operation in operations:
-            hutil = parse_context(operation)
+        hutil = parse_context(operation)
+        if is_vm_supported_for_extension():
             exit_code = operations[operation](hutil)
-            if exit_code is not 0:
-                # If Daniel replies favorably, then if an exit code is among the pre-reqs we can return that and print out the pre-req
-                message = (operation + ' failed with exit code {0}').format(exit_code)
+        else:
+            log_and_exit(hutil, operation, 51, 'Unsupported operation system')
+
+        if exit_code is not 0:
+            message = (operation + ' failed with exit code {0}').format(exit_code)
 
     except ValueError as e:
         exit_code = 11
@@ -99,14 +99,7 @@ def main():
             message = (operation + ' failed with error: {0}').format(e.message)
 
     # Finish up and log messages
-    if exit_code is 0:
-        waagent.Log(message)
-        hutil.log(message)
-        hutil.do_exit(exit_code, operation, 'success', str(exit_code), message)
-    else:
-        waagent.Error(message)
-        hutil.error(message)
-        hutil.do_exit(exit_code, operation, 'failed', str(exit_code), message)
+    log_and_exit(hutil, operation, exit_code, message)
 
 
 def parse_context(operation):
@@ -115,14 +108,69 @@ def parse_context(operation):
     return hutil
 
 
-def dummy_command(operation, status, msg):
-    hutil = parse_context(operation)
-    hutil.do_exit(0, operation, status, '0', msg)
+def is_vm_supported_for_extension():
+    '''
+    Returns for platform.linux_distribution() vary widely in format, such as '7.3.1611' returned
+    for a machine with CentOS 7, so the first provided digits must match
+    '''
+    supported_dists = {'redhat' : ('5', '6', '7'), # CentOS
+                       'centos' : ('5', '6', '7'), # CentOS
+                       'red hat' : ('5', '6', '7'), # Oracle, RHEL
+                       'oracle' : ('5', '6', '7'), # Oracle
+                       'debian' : ('6', '7', '8'), # Debian
+                       'ubuntu' : ('12.04', '14.04', '15.04', '15.10', '16.04'), # Ubuntu
+                       'suse' : ('11', '12') #SLES
+    }
+
+    try:
+        vm_dist, vm_ver, vm_id = platform.linux_distribution()
+    except AttributeError:
+        vm_dist, vm_ver, vm_id = platform.dist()
+
+    vm_supported = False
+
+    # Find this VM distribution in the supported list
+    for supported_dist in supported_dists.keys():
+        if not vm_dist.lower().startswith(supported_dist):
+            continue
+
+        # Check if this VM distribution version is supported
+        vm_ver_split = vm_ver.split('.')
+        for supported_ver in supported_dists[supported_dist]:
+            supported_ver_split = supported_ver.split('.')
+
+            vm_ver_match = True
+            for idx, supported_ver_num in enumerate(supported_ver_split):
+                try:
+                    vm_ver_num = vm_ver_split[idx]
+                except IndexError:
+                    vm_ver_match = False
+                    break
+                if vm_ver_num is not supported_ver_num:
+                    vm_ver_match = False
+                    break
+            if vm_ver_match:
+                vm_supported = True
+                break
+
+        if vm_supported:
+            break
+
+    return vm_supported
+
+
+def dummy_command(hutil):
     return 0
 
 
 def run_command_with_retries(hutil, cmd, file_directory, operation, extension_short_name, retries,
-                             initial_sleep_time = 5, sleep_increase_factor = 2):
+                             initial_sleep_time = 30, sleep_increase_factor = 1):
+    '''
+    Some commands fail because the package manager is locked (apt-get/dpkg only); this will
+      allow retries on failing commands.
+    Logic used: will retry up to retries times with initial_sleep_time in between tries
+    Note: install operation times out from WAAgent at 15 minutes, so do not wait longer.
+    '''
     try_count = 0
     sleep_time = initial_sleep_time # seconds
     while try_count <= retries:
@@ -139,6 +187,17 @@ def run_command_with_retries(hutil, cmd, file_directory, operation, extension_sh
     return exit_code
 
 
+def log_and_exit(hutil, operation, exit_code = 1, message = ''):
+    if exit_code is 0:
+        waagent.Log(message)
+        hutil.log(message)
+        hutil.do_exit(exit_code, operation, 'success', str(exit_code), message)
+    else:
+        waagent.Error(message)
+        hutil.error(message)
+        hutil.do_exit(exit_code, operation, 'failed', str(exit_code), message)
+
+
 def install(hutil):
     file_directory = os.path.join(os.getcwd(), PackagesDirectory)
     file_path = os.path.join(file_directory, BundleFileName)
@@ -149,7 +208,7 @@ def install(hutil):
 
     # Retry, since install can fail due to concurrent package operations
     exit_code = run_command_with_retries(hutil, cmd, file_directory, 'Install', ExtensionShortName,
-                                         retries = 3)
+                                         retries = 10)
     return exit_code
 
 
@@ -161,7 +220,7 @@ def uninstall(hutil):
 
     # Retry up to three times, since uninstall can fail due to concurrent package operations
     exit_code = run_command_with_retries(hutil, cmd, file_directory, 'Uninstall',
-                                         ExtensionShortName, retries = 3)
+                                         ExtensionShortName, retries = 10)
     return exit_code
 
 
@@ -258,7 +317,10 @@ def disable(hutil):
 operations = {'Disable' : disable,
               'Uninstall' : uninstall,
               'Install' : install,
-              'Enable' : enable
+              'Enable' : enable,
+              # Upgrade is noop since omsagent.py->install() will be called everytime upgrade
+              #   is done due to upgradeMode = "UpgradeWithInstall" set in HandlerManifest
+              'Update' : dummy_command
 }
 
 


### PR DESCRIPTION
Also merged Azure master into my feature branch.

@varunkumta @NarineM These is not the final versions of the changes, but I wanted to get your eyes on them as soon as possible. Let me know what you think.

Once I release an OMSAgent bundle that exits with more specific error codes, those numbers can be returned to the user and logged everywhere.
Along with this, I've also tried to clean up our code a little bit so that errors don't fall through the cracks.

Changes still in progress: associating error codes with more specific messages; testing this extension code; testing all OMSAgent exit scenarios.